### PR TITLE
fix SNAFU blocklist URL

### DIFF
--- a/scripts/source.csv
+++ b/scripts/source.csv
@@ -1,7 +1,7 @@
 name,type,url
 1Hosts,domain,https://raw.githubusercontent.com/badmojr/1Hosts/master/Xtra/domains.txt
 Badd-Boyz-Hosts,rfc952,https://raw.githubusercontent.com/mitchellkrogza/Badd-Boyz-Hosts/master/hosts
-RooneyMcNibNug,https://raw.githubusercontent.com/RooneyMcNibNug/pihole-stuff/master/SNAFU.txt
+RooneyMcNibNug,domain,https://raw.githubusercontent.com/RooneyMcNibNug/pihole-stuff/master/SNAFU.txt
 ShadowWhispererAds,domain,https://raw.githubusercontent.com/ShadowWhisperer/BlockLists/master/Lists/Ads
 ShadowWhispererApple,domain,https://raw.githubusercontent.com/ShadowWhisperer/BlockLists/master/Lists/Apple
 ShadowWhispererBloat,domain,https://raw.githubusercontent.com/ShadowWhisperer/BlockLists/master/Lists/Bloat

--- a/scripts/source.csv
+++ b/scripts/source.csv
@@ -1,7 +1,7 @@
 name,type,url
 1Hosts,domain,https://raw.githubusercontent.com/badmojr/1Hosts/master/Xtra/domains.txt
 Badd-Boyz-Hosts,rfc952,https://raw.githubusercontent.com/mitchellkrogza/Badd-Boyz-Hosts/master/hosts
-RooneyMcNibNug,domain,https://github.com/mitchellkrogza/Phishing.Database/issues/899
+RooneyMcNibNug,https://raw.githubusercontent.com/RooneyMcNibNug/pihole-stuff/master/SNAFU.txt
 ShadowWhispererAds,domain,https://raw.githubusercontent.com/ShadowWhisperer/BlockLists/master/Lists/Ads
 ShadowWhispererApple,domain,https://raw.githubusercontent.com/ShadowWhisperer/BlockLists/master/Lists/Apple
 ShadowWhispererBloat,domain,https://raw.githubusercontent.com/ShadowWhisperer/BlockLists/master/Lists/Bloat


### PR DESCRIPTION
Hi - It looks like with https://github.com/external-sources/hosts-sources/commit/c3254c9d273f6766223e537798309487a0a2ad65#diff-86e5b0318b37a34efb3caf9121d42ce93fb2506cbf1766d86d2119f16b7126e4R4 a link to a github issue was erroneously added instead of the link to URL for this bocklist.

This should fix it.